### PR TITLE
Added some first FAQ entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,19 @@
 
 The godot-rust book is a user guide for the Rust bindings. The book is currently an early work-in-progress, and contributions are very welcome.
 
-The book is built with [mdBook](https://github.com/rust-lang-nursery/mdBook). There is currently no online version available. To build the book locally, you can run:
+An online version of the book is available at [godot-rust.github.io/book/](https://godot-rust.github.io/book/).
+
+The book is built with [mdBook](https://github.com/rust-lang-nursery/mdBook). To build the book locally, you can run:
 
 ```
 $ cargo install mdbook
-$ mdbook build book
+$ mdbook build
 ```
 
 To run a local server with automatic updates while editing the book, run:
 
 ```
-$ mdbook serve book
+$ mdbook serve
 ```
 
 This repository is for documentation only. Please make pull requests for the library itself in the [main repo](https://github.com/godot-rust/godot-rust).

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -4,6 +4,7 @@
 - [Getting Started](./getting-started.md)
   - [Setup](./getting-started/setup.md)
   - [Hello, world!](./getting-started/hello-world.md)
+- [FAQ](./faq.md)
 - [An Overview of GDNative](./gdnative-overview.md)
 - [Testing](./testing.md)
   - [Structuring Code for Testing](./testing/structure.md)

--- a/src/faq.md
+++ b/src/faq.md
@@ -1,0 +1,114 @@
+# FAQ
+
+## Passing additional arguments to a class constructor
+
+**Question**
+
+A native script type needs to implement `fn new(_owner: &Node) -> Self`.
+Is it possible to pass additional arguments to `new`?
+
+**Answer**
+
+Unfortunately this is currently a general limitation of GDNative (see [related issue](https://github.com/godotengine/godot/issues/23260)).
+
+As a result, a common pattern to work-around the limitation is to use explicit initialization methods. For instance:
+
+```rust
+#[derive(NativeClass)]
+#[inherit(Object)]
+struct DataWrapper {
+    data: Option<Data>,
+}
+
+#[godot::methods]
+impl DataWrapper {
+    fn new(_owner: &Object) -> Self {
+        DataWrapper {
+            data: None,
+        }
+    }
+
+    #[export]
+    fn set_data(&mut self, _owner: &Object, additional_arg1: i32, additional_arg2: i32) {
+        self.data = Some(Data::new(additional_arg1, additional_arg2));
+    }
+}
+```
+
+
+## Static methods
+
+**Question**
+
+In GDScript, classes can have static methods.
+However, when I try to omit `self` in the exported method signature, I'm getting a compile error.
+How can I implement a static method?
+
+**Answer**
+
+This is another limitation of GDNative -- static methods are not supported in general.
+
+As a work-around, it is possible to use a ZST (zero-sized type):
+
+```rust
+#[derive(NativeClass)]
+#[inherit(Object)]
+pub struct StaticUtil;
+
+#[godot::methods]
+impl StaticUtil {
+    #[export]
+    fn compute_something(&self, _owner: &Object, input: i32) -> i32 {
+        godot_print!("pseudo-static computation");
+        2 * input
+    }
+}
+```
+
+The type needs to be instantiated somewhere on GDScript level.
+Good places for instantiation are for instance:
+
+- as a member of a long-living util object,
+- as a [singleton auto-load object](https://docs.godotengine.org/en/stable/getting_started/step_by_step/singletons_autoload.html).
+
+
+## Converting a Godot type to the underlying Rust type
+
+**Question**
+
+I have a method that takes an argument `my_object` as a `Variant`.
+I know that this object is actually another native script, i.e., it is backed by some Rust data structure, called say `MyObject`.
+How can I convert the `Variant` to the underlying Rust type?
+
+**Answer**
+
+This conversion can be accomplished by casting the `Variant` to a `Ref`, obtaining the underlying `RefInstance`, and mapping over it to access the Rust data type:
+
+```rust
+#[godot::methods]
+impl AnotherNativeScript {
+
+    #[export]
+    pub fn method_accepting_my_object(&self, _owner: &Object, my_object: Variant) {
+        // 1. Cast Variant to Ref of associated Godot type, and convert to TRef.
+        let my_object = unsafe {
+            my_object
+                .try_to_object::<Object>()
+                .expect("Failed to convert my_object variant to object")
+                .assume_safe()
+        };
+        // 2. Obtain a RefInstance.
+        let my_object = my_object
+            .cast_instance::<MyObject>()
+            .expect("Failed to cast my_object object to instance");
+        // 3. Map over the RefInstance to extract the underlying user data.
+        my_object
+            .map(|my_object, _| {
+                // now my_object is of type MyObject
+            })
+            .expect("Failed to map over my_object instance");
+    }
+
+}
+
+```

--- a/src/faq.md
+++ b/src/faq.md
@@ -51,8 +51,7 @@ This is another limitation of GDNative -- static methods are not supported in ge
 As a work-around, it is possible to use a ZST (zero-sized type):
 
 ```rust
-#[derive(NativeClass)]
-#[derive(Copy, Clone, Default)]
+#[derive(NativeClass, Copy, Clone, Default)]
 #[user_data(Aether<StaticUtil>)]
 #[inherit(Object)]
 pub struct StaticUtil;


### PR DESCRIPTION
To make it more easy to add content to the user guide I thought I'll start a kind of FAQ section. Because of the assorted nature of an FAQ, knowledge can be added without worrying too much about arranging it in a meaningful order. Maybe some parts can be restructured later.

So far I have only added topics I had been involved with, mainly because they are the only ones I can roughly answer ;). My answers are still largely guesses, and may need some refinement.

I guess many of the [issues marked as question](https://github.com/godot-rust/godot-rust/issues?q=label%3Aquestion+) are good candidates for the FAQ as well.