### PR TITLE
Misc fixes in Getting Started

### DIFF
--- a/src/faq.md
+++ b/src/faq.md
@@ -4,11 +4,11 @@
 
 **Question**
 
-What is the `BorrowFailed` error and why I keep getting it? I'm only trying to call another method that takes `&mut self` while holding one!
+What is the `BorrowFailed` error and why do I keep getting it? I'm only trying to call another method that takes `&mut self` while holding one!
 
 **Answer**
 
-In Rust, [there can only be *one* `&mut` reference to the same memory location at the same time](https://docs.rs/dtolnay/0.0.9/dtolnay/macro._02__reference_types.html). To enforce this while making simple use cases easier, the bindings make use of [interior mutability](https://doc.rust-lang.org/book/ch15-05-interior-mutability.html). This works like a lock: whenever a method with `&mut self` is called, it will try to obtain a lock on the `self` value, and hold it *until it returns*. As a result, if another method that takes `&mut self` in called in the meantime for whatever reason (e.g. signals), the lock will fail and a error (`BorrowFailed`) will be produced.
+In Rust, [there can only be *one* `&mut` reference to the same memory location at the same time](https://docs.rs/dtolnay/0.0.9/dtolnay/macro._02__reference_types.html). To enforce this while making simple use cases easier, the bindings make use of [interior mutability](https://doc.rust-lang.org/book/ch15-05-interior-mutability.html). This works like a lock: whenever a method with `&mut self` is called, it will try to obtain a lock on the `self` value, and hold it *until it returns*. As a result, if another method that takes `&mut self` is called in the meantime for whatever reason (e.g. signals), the lock will fail and an error (`BorrowFailed`) will be produced.
 
 It's relatively easy to work around this problem, though: Because of how the user-data container works, it can only see the outermost layer of your script type - the entire structure. This is why it's stricter than what is actually required. If you run into this problem, you can [introduce finer-grained interior mutability](https://doc.rust-lang.org/book/ch15-05-interior-mutability.html) in your own type, and modify the problematic exported methods to take `&self` instead of `&mut self`.
 
@@ -119,7 +119,7 @@ impl AnotherNativeScript {
         // 3. Map over the RefInstance to extract the underlying user data.
         my_object
             .map(|my_object, _owner| {
-                // now my_object is of type MyObject
+                // Now my_object is of type MyObject.
             })
             .expect("Failed to map over my_object instance");
     }

--- a/src/getting-started/hello-world.md
+++ b/src/getting-started/hello-world.md
@@ -2,7 +2,7 @@
 
 Follow this tutorial to learn how to create an empty project that simply prints "Hello, world!" to the Godot console on ready. The code might not compile or work as intended while it's in-progress, but at the end of this section, the code will be compiling and working fine.
 
-The full, finished code is available in the main repo: https://github.com/godot-rust/godot-rust/tree/master/examples/hello_world
+The full, finished code is available in the main repo: [https://github.com/godot-rust/godot-rust/tree/master/examples/hello_world](https://github.com/godot-rust/godot-rust/tree/master/examples/hello_world).
 
 ## Creating the project
 
@@ -22,9 +22,8 @@ Your file structure should look like this:
 │   ├   Cargo.toml
 ├─── my-godot-project
 │   ├─── .import
-│   └─── assets
-│   │   ├   icon.png
-│   │   └   icon.png.import
+│   ├   icon.png
+│   ├   icon.png.import
 │   └   project.godot
 ```
 
@@ -83,15 +82,15 @@ This declares an empty callback function, which is called when the library is lo
 godot_init!(init);
 ```
 
-These macros define the necessary C callbacks used by Godot. You only need *one* of these in the entire library. Note how the `init` function defined earlier is given to the `godot_nativescript_init` macro as a callback.
+This macro defines the necessary C callbacks used by Godot. You only need *one* invocation of this macro in the entire library. Note how the `init` function defined earlier is given to the `godot_init!` macro as a callback.
 
 > ### GDNative internals
 >
-> The purposes of these macros will be discussed in detail in [_An Overview of GDNative_](../gdnative-overview.md). For now, treat these as magic incantations.
+> The purposes of this macro will be discussed in detail in [_An Overview of GDNative_](../gdnative-overview.md). For now, treat it as a magic incantation.
 
 ## Your first script
 
-With the boilerplate put into place, you can now create your first Rust script! We will go step by step and discover what's needed to create script "class"es. Intermediate code versions might not compile, but at the end of this section it should be working!
+With the boilerplate put into place, you can now create your first Rust script! We will go step by step and discover what's needed to create script "classes". Intermediate code versions might not compile, but at the end of this section it should be working!
 
 A script is simply a Rust type that implements (derives) the `NativeScript` trait:
 
@@ -128,7 +127,7 @@ impl HelloWorld {
 }
 ```
 
-The `HelloWorld` type is like any regular Rust type, and can have any number of ordinary `impl` blocks. However, it must have **one and only one** `impl` block with the `#[methods]` attribute, which tells godot-rust to generate code that automatically bind any exported methods to Godot.
+The `HelloWorld` type is like any regular Rust type, and can have any number of ordinary `impl` blocks. However, it must have **one and only one** `impl` block with the `#[methods]` attribute, which tells godot-rust to generate code that automatically binds any exported methods to Godot.
 
 ## Creating the NativeScript resource
 
@@ -175,9 +174,9 @@ Now, re-compile the crate using `cargo build` and copy the resulting binary to t
 
 ## Wrapping it up
 
-Congratulations! You have just created your first Rust GDNative library. You have learned how to expose scripts, methods to Godot using the bindings, and how to use them in Godot. A lot of the details are still unexplained, but you're off to a good start!
+Congratulations! You have just created your first Rust GDNative library. You have learned how to expose scripts and methods to Godot using the bindings, and how to use them in Godot. A lot of the details are still unexplained, but you're off to a good start!
 
-You can find the full code for this example in the main repo: https://github.com/godot-rust/godot-rust/tree/master/examples/hello_world
+You can find the full code for this example in the main repo: [https://github.com/godot-rust/godot-rust/tree/master/examples/hello_world](https://github.com/godot-rust/godot-rust/tree/master/examples/hello_world).
 
 ## Work-in-progress
 

--- a/src/getting-started/setup.md
+++ b/src/getting-started/setup.md
@@ -6,7 +6,7 @@ Before we can start creating a hello-world project using godot-rust, we'll need 
 
 The default API version is currently 3.2.3-stable. For the rest of the tutorial, we'll assume that you have Godot 3.2.3-stable installed, and available in your `PATH` as `godot`.
 
-You may download binaries of Godot 3.2.3-stable from the official repository: https://downloads.tuxfamily.org/godotengine/3.2.3/
+You may download binaries of Godot 3.2.3-stable from the official repository: [https://downloads.tuxfamily.org/godotengine/3.2.3/](https://downloads.tuxfamily.org/godotengine/3.2.3/).
 
 > ### Using another build of the engine
 >
@@ -14,7 +14,7 @@ You may download binaries of Godot 3.2.3-stable from the official repository: ht
 
 ## Rust
 
-[rustup](https://rustup.rs/) is the recommended way to install the Rust toolchain, including the compiler, standard library, and Cargo, the package manager. Visit https://rustup.rs/ to see instructions for your platform.
+[rustup](https://rustup.rs/) is the recommended way to install the Rust toolchain, including the compiler, standard library, and Cargo, the package manager. Visit [https://rustup.rs/](https://rustup.rs/) to see instructions for your platform.
 
 After installation of rustup and the `stable` toolchain, check that they were installed properly:
 
@@ -33,11 +33,11 @@ When working on Windows, it's also necessary to install the [Visual Studio Build
 
 ## LLVM
 
-The godot-rust bindings depend on `bindgen`, which in turn [depends on LLVM](https://rust-lang.github.io/rust-bindgen/requirements.html). You may download LLVM binaries from https://releases.llvm.org/.
+The godot-rust bindings depend on `bindgen`, which in turn [depends on LLVM](https://rust-lang.github.io/rust-bindgen/requirements.html). You may download LLVM binaries from [https://releases.llvm.org/](https://releases.llvm.org/).
 
 After installation, check that LLVM was installed properly:
 
 ```bash
-# Check if CLang is installed and registered in PATH
+# Check if Clang is installed and registered in PATH
 clang -v
 ```


### PR DESCRIPTION
- Make links clickable
- Fix default structure of Godot project
- Fix plural in reference to macros from earlier versions
- Typo fixes

---

Some of the changes made might be up for discussion / a matter of taste, so feel free to tell me what you prefer to keep unchanged, and I'll amend the commit.