### PR TITLE
Update mdbook (0.4.1 -> 0.4.12), fixes CVE-2020-26297

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Build book
       run: |
-        wget https://github.com/rust-lang/mdBook/releases/download/v0.4.1/mdbook-v0.4.1-x86_64-unknown-linux-gnu.tar.gz -O /tmp/mdbook.tar.gz
+        wget https://github.com/rust-lang/mdBook/releases/download/v0.4.12/mdbook-v0.4.12-x86_64-unknown-linux-gnu.tar.gz -O /tmp/mdbook.tar.gz
         /bin/tar -xvzf /tmp/mdbook.tar.gz -C /tmp
         /tmp/mdbook build
         


### PR DESCRIPTION
Fixes a vulnerability in mdbook, that allows arbitrary JavaScript execution from search bar input.
https://blog.rust-lang.org/2021/01/04/mdbook-security-advisory.html