### PR TITLE
Fix: git examples/abc-defgh links, hello_world -> hello-world

### DIFF
--- a/src/faq/configuration.md
+++ b/src/faq/configuration.md
@@ -95,7 +95,7 @@ fn init(handle: InitHandle) {
 }
 ```
 
-Please also see the [native_plugin](https://github.com/godot-rust/godot-rust/tree/master/examples/native-plugin) that is the Rust version of the [editor plugin](https://docs.godotengine.org/en/stable/tutorials/plugins/editor/index.html) tutorial.
+Please also see the [native-plugin](https://github.com/godot-rust/godot-rust/tree/master/examples/native-plugin) that is the Rust version of the [editor plugin](https://docs.godotengine.org/en/stable/tutorials/plugins/editor/index.html) tutorial.
 
 **Important**
 

--- a/src/faq/configuration.md
+++ b/src/faq/configuration.md
@@ -95,7 +95,7 @@ fn init(handle: InitHandle) {
 }
 ```
 
-Please also see the [native_plugin](https://github.com/godot-rust/godot-rust/tree/master/examples/native_plugin) that is the Rust version of the [editor plugin](https://docs.godotengine.org/en/stable/tutorials/plugins/editor/index.html) tutorial.
+Please also see the [native_plugin](https://github.com/godot-rust/godot-rust/tree/master/examples/native-plugin) that is the Rust version of the [editor plugin](https://docs.godotengine.org/en/stable/tutorials/plugins/editor/index.html) tutorial.
 
 **Important**
 

--- a/src/getting-started.md
+++ b/src/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-The getting started tutorial will introduce you to basic godot-rust concepts. At the end of the tutorial, you'll have a working copy of the [dodge-the-creeps example](https://github.com/godot-rust/godot-rust/tree/master/examples/dodge_the_creeps) from the main repo.
+The getting started tutorial will introduce you to basic godot-rust concepts. At the end of the tutorial, you'll have a working copy of the [dodge-the-creeps example](https://github.com/godot-rust/godot-rust/tree/master/examples/dodge-the-creeps) from the main repo.
 
 This tutorial assumes some experience with Godot's GUI and GDScript. It assumes a basic understanding of Rust itself.
 

--- a/src/getting-started/hello-world.md
+++ b/src/getting-started/hello-world.md
@@ -2,7 +2,7 @@
 
 Follow this tutorial to learn how to create an empty project that simply prints "Hello, world!" to the Godot console on ready. The code might not compile or work as intended while it's in-progress, but at the end of this section, the code will be compiling and working fine.
 
-The full, finished code is available in the main repo: [https://github.com/godot-rust/godot-rust/tree/master/examples/hello_world](https://github.com/godot-rust/godot-rust/tree/master/examples/hello_world).
+The full, finished code is available in the main repo: [https://github.com/godot-rust/godot-rust/tree/master/examples/hello-world](https://github.com/godot-rust/godot-rust/tree/master/examples/hello-world).
 
 
 ## Creating the project

--- a/src/getting-started/hello-world.md
+++ b/src/getting-started/hello-world.md
@@ -182,7 +182,7 @@ Now, re-compile the crate using `cargo build` and copy the resulting binary to t
 
 Congratulations! You have just created your first Rust GDNative library. You have learned how to expose scripts and methods to Godot using the bindings, and how to use them in Godot. A lot of the details are still unexplained, but you're off to a good start!
 
-You can find the full code for this example in the main repo: [https://github.com/godot-rust/godot-rust/tree/master/examples/hello_world](https://github.com/godot-rust/godot-rust/tree/master/examples/hello_world).
+You can find the full code for this example in the main repo: [https://github.com/godot-rust/godot-rust/tree/master/examples/hello-world](https://github.com/godot-rust/godot-rust/tree/master/examples/hello-world).
 
 
 ## Work-in-progress

--- a/src/recipes/nix-build-system.md
+++ b/src/recipes/nix-build-system.md
@@ -6,7 +6,7 @@
 
 This tutorial assumes that Nix is [installed](https://nixos.org/download.html#nix-quick-install) in your system.
 
-To begin with, we are going to create a new project using the [Hello, world!](../getting-started/hello-world.md) guide in Getting Started. Note that the full source code for the project is available at https://github.com/godot-rust/godot-rust/tree/master/examples/hello_world. Because we aren't using the default build system explained in [setup](../getting-started/setup.md), you should only be worried about the content of the project rather than the dependencies.
+To begin with, we are going to create a new project using the [Hello, world!](../getting-started/hello-world.md) guide in Getting Started. Note that the full source code for the project is available at https://github.com/godot-rust/godot-rust/tree/master/examples/hello-world. Because we aren't using the default build system explained in [setup](../getting-started/setup.md), you should only be worried about the content of the project rather than the dependencies.
 
 
 ## Specifying dependencies


### PR DESCRIPTION
correction of repo link for hello-world example