### PR TITLE
Added note about the export attribute rename

### DIFF
--- a/src/rust-binding/methods.md
+++ b/src/rust-binding/methods.md
@@ -2,6 +2,11 @@
 
 In order to receive data from Godot, you can export methods. With the `#[export]` attribute, godot-rust takes care of method registration and serialization. Note that the constructor is not annotated with `#[export]`.
 
+> #### Upcoming API changes
+> `#[export]` is being renamed as `#[godot]` and will soon be deprecated, and later removed in godot-rust 0.11.
+>
+> For more information, see [gdnative::derive::NativeClass](https://godot-rust.github.io/docs/gdnative/derive/derive.NativeClass.html).
+
 The exported method's first parameter is always `&self` or `&mut self` (operating on the Rust object), and the second parameter is `&T` or `TRef<T>` (operating on the Godot base object, with `T` being the inherited type).
 
 ```rust


### PR DESCRIPTION
I was tinkering with some recently updated examples and was a bit
confused by my lack of the `godot` NativeClass attribute, so I thought
it may be a good call our here for others as well.