### PR TITLE
Changed signal declaration, so it fits the current docs (0.10.0)

### DIFF
--- a/src/faq/code.md
+++ b/src/faq/code.md
@@ -64,7 +64,7 @@ struct SignalEmitter {
 #[methods]
 impl SignalEmitter {
     fn register_signals(builder: &ClassBuilder<Self>) {
-        builder.add_signal(Signal { name: "updated", args: &[] });
+        builder.signal("updated").done();
     }
 
     fn new(_owner: &Node) -> Self {


### PR DESCRIPTION
Updated the shown signal registration, so it uses the correct/actual syntax (as seen in the docs).