### PR TITLE
FAQ: Added unwraping after `cast` call, so it compiles correctly.

### DIFF
--- a/src/faq/code.md
+++ b/src/faq/code.md
@@ -404,7 +404,8 @@ impl MyNode {
             .get_node("Node2D")
             .expect("this node must have a child with the path `Node2D`");
         let node2d = unsafe { node2d.assume_safe() };
-        let node2d = node2d.cast::<Node2D>();
+        let node2d = node2d.cast::<Node2D>()
+                        .expect("child must be of type 'Node2D'");
         self.node2d = Some(node2d.claim());
 
         // Get an existing child node that is a Rust class.

--- a/src/faq/code.md
+++ b/src/faq/code.md
@@ -392,7 +392,7 @@ struct MyNode {
     // late-initialization is modeled with Option
     // the Default derive will initialize both to None
     node2d: Option<Ref<Node>>,
-    instance: Option<Ref<MyClass>>,
+    instance: Option<Instance<MyClass>>,
 }
 
 #[methods]


### PR DESCRIPTION
The `onready var FAQ` had a missing `unwrap`, which didn't allow the code to compile correctly.
Also adjusted `struct` declaration, so `NativeClass` actually uses the `Option<Instance<T>>` format.

This is the only instance, where that is missing in the book FYI (picture attached)

![image](https://user-images.githubusercontent.com/8035238/179569656-ab22b5bb-1ae5-486e-b1ab-feac769a228d.png)
