### PR TITLE
Added clarification to `config.toml`

### DIFF
--- a/src/exporting/html5.md
+++ b/src/exporting/html5.md
@@ -72,7 +72,7 @@ Set the newly built export template as a [custom template](https://user-images.g
 
 ### Building your Rust code
 
-In your project's `config.toml`, add the following:
+In your project's `.cargo/config.toml` [(see Cargo Docs)](https://doc.rust-lang.org/cargo/reference/config.html), add the following:
 
 ```toml
 [target.wasm32-unknown-emscripten]
@@ -99,6 +99,8 @@ The result is a `.wasm` file that you add in your `GDNativeLibrary` properties u
 Compile time:
 * `failed to run custom build command for gdnative-sys v0.10.1`, `fatal error: 'wchar.h' file not found`: Emscripten cache not populated, build Godot export template first
 * `undefined symbol: __cxa_is_pointer_type`: You need to build with `-Clink-arg=-sSIDE_MODULE=2`
+* `error: undefined symbol: main/__main_argc_argv (referenced by top-level compiled C/C++ 
+code)`: Your `.cargo/config.toml` was not loaded. See [Cargo Docs](https://doc.rust-lang.org/cargo/reference/config.html) and verify it's location.
 
 Runtime:
 * `indirect call signature mismatch`: Possibly due to Emscripten version mismatch between Godot and Rust

--- a/src/exporting/html5.md
+++ b/src/exporting/html5.md
@@ -100,7 +100,7 @@ Compile time:
 * `failed to run custom build command for gdnative-sys v0.10.1`, `fatal error: 'wchar.h' file not found`: Emscripten cache not populated, build Godot export template first
 * `undefined symbol: __cxa_is_pointer_type`: You need to build with `-Clink-arg=-sSIDE_MODULE=2`
 * `error: undefined symbol: main/__main_argc_argv (referenced by top-level compiled C/C++ 
-code)`: Your `.cargo/config.toml` was not loaded. See [Cargo Docs](https://doc.rust-lang.org/cargo/reference/config.html) and verify it's location.
+code)`: Your `.cargo/config.toml` was not loaded. See [Cargo Docs](https://doc.rust-lang.org/cargo/reference/config.html) and verify its location.
 
 Runtime:
 * `indirect call signature mismatch`: Possibly due to Emscripten version mismatch between Godot and Rust


### PR DESCRIPTION
It too me 3 days to figure out that wasn't `Cargo.toml`. Added the `.cargo/` and link to docs might help clarify to people who haven't used/needed `config.toml` in projects before.

Added clarification and link to docs as well as the error message I encountered.