### PR TITLE
Clarify the LLVM dependency on Windows

### DIFF
--- a/src/gdnative/intro/setup.md
+++ b/src/gdnative/intro/setup.md
@@ -27,9 +27,9 @@ rustc --version
 cargo -V
 ```
 
-### Windows
+## Windows
 
-When working on Windows, it's also necessary to install the [Visual Studio Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/), or the full Visual Studio (*not* Visual Studio Code). More details can be found on [Working with Rust on Windows](https://github.com/rust-lang/rustup#working-with-rust-on-windows).
+When working on Windows, it's also necessary to install the [Visual Studio Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/), or the full Visual Studio (*not* Visual Studio Code). More details can be found on [Working with Rust on Windows](https://github.com/rust-lang/rustup#working-with-rust-on-windows). Also note that LLVM is also required on top of those dependencies to be able to build your godot-rust project, see the next section for more information.
 
 ## LLVM
 

--- a/src/gdnative/intro/setup.md
+++ b/src/gdnative/intro/setup.md
@@ -29,7 +29,7 @@ cargo -V
 
 ## Windows
 
-When working on Windows, it's also necessary to install the [Visual Studio Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/), or the full Visual Studio (*not* Visual Studio Code). More details can be found on [Working with Rust on Windows](https://github.com/rust-lang/rustup#working-with-rust-on-windows). Also note that LLVM is also required on top of those dependencies to be able to build your godot-rust project, see the next section for more information.
+When working on Windows, it's also necessary to install the [Visual Studio Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/), or the full Visual Studio (*not* Visual Studio Code). More details can be found on [Working with Rust on Windows](https://github.com/rust-lang/rustup#working-with-rust-on-windows). Note that LLVM is also required on top of those dependencies to build your godot-rust project, see the next section for more information.
 
 ## LLVM
 


### PR DESCRIPTION
I had some trouble understanding that I had to install LLVM separately and it wasn't included with the Visual Studio as a dependency. I'm creating this PR because it confused me and I saw some people on the discord go through this as well, and that's how I "figured it out myself".