### PR TITLE
Fix nix page

### DIFF
--- a/src/gdnative/recipes/nix-build-system.md
+++ b/src/gdnative/recipes/nix-build-system.md
@@ -37,7 +37,7 @@ in
             pkgs.godot
 
             # The support for OpenGL in Nix
-            nixgl.nixGLDefault
+            nixgl.auto.nixGLDefault
         ];
 
         # Point bindgen to where the clang library would be


### PR DESCRIPTION
I noticed, that one of the packages used in the nix shell example doesn't work
anymore. I made the necessary changes and with this it builds again on my
machine.
