### PR TITLE
Cleared up a misconception on what deferred calls do

### DIFF
--- a/src/gdnative/bind/calling-gdscript.md
+++ b/src/gdnative/bind/calling-gdscript.md
@@ -121,7 +121,7 @@ fn update_mission_ui(ui_node: Ref<CanvasItem>) {
 }
 ```
 
-Besides [`Object::call()`](https://docs.rs/gdnative/latest/gdnative/api/struct.Object.html#method.call), alternative methods `callv()` (accepting a `VariantArray`) and `call_deferred()` (calling the next frame) exist, but the principle stays the same.
+Besides [`Object::call()`](https://docs.rs/gdnative/latest/gdnative/api/struct.Object.html#method.call), alternative methods `callv()` (accepting a `VariantArray`) and `call_deferred()` (calling at the end of the frame) exist, but the principle stays the same.
 
 For long parameter lists, it often makes sense to bundle related functionality into a new class, let's say `Stats` in the above example. When working with classes, you can convert both `Ref` (for Godot/GDScript classes) and `Instance` (for native classes) to `Variant` by means of the `OwnedToVariant` trait:
 

--- a/src/gdnative/faq/code.md
+++ b/src/gdnative/faq/code.md
@@ -104,7 +104,7 @@ The problem is that, unless the nodes all connect with the `Object::CONNECT_DEFE
 
 There are two ways to solve it.
 
-1. Ensure that all nodes use `Object::CONNECT_DEFERRED` since this will ensure that the callbacks wait until the idle_frame signal to borrow the data.
+1. Ensure that all nodes use `Object::CONNECT_DEFERRED`. This will delay the callbacks until the end of the current physics or idle frame, long after the current borrow on the data ends.
 2. Store `data` in a `RefCell<LargeData>` if it should only be accessed from the same thread (such as with signals) or `Mutex<LargeData>` if you need thread-safety. Then you can modify `update_data()` to the following snippet:
 
 ```rust


### PR DESCRIPTION
The godot docs have contradictory explanations, but deferred calls get pushed to a queue that gets flushed both at the end of physics and idle frames. when it gets flushed, all pending calls are called until it's empty (so calling something as deferred from something that's called as deferred will still happen within the same frame, no matter how many times it recurses)
(strangely, in godot 3 it seems to also flush before idle frames, while in godot 4 it flushes before physics frames. not sure why either is done)