### PR TITLE
Inline code fix for hello-world.md

### DIFF
--- a/src/gdext/intro/hello-world.md
+++ b/src/gdext/intro/hello-world.md
@@ -287,7 +287,7 @@ impl Player {
 	#[func]
 	fn increase_speed(&mut self, amount: f64) {
 		self.speed += amount;
-		self.emit_signal("speed_increased".into(), &[]);
+		self.sprite.emit_signal("speed_increased".into(), &[]);
 	}
 
 	#[signal]


### PR DESCRIPTION
Recent change in master makes emit_signal only available on the base.

Caught this while following along with the tutorial, figured I'd help out where I can. Great work btw, the rust API feels pretty ergonomic so far while still accommodating the non-Rusty patterns of a C++ game engine.